### PR TITLE
.github: add workflow for Ruby tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,18 @@
+name: ruby
+
+on: pull_request
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - name: Test code embedded in blog articles
+      run: |
+        ruby articles/code/*.rb


### PR DESCRIPTION
Some blog articles have embedded Ruby code.
Run them when opening pull requests.