### PR TITLE
main.go: switch from blackfriday to gomarkdown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/croaky/blog
 
 go 1.14
 
-require (
-	github.com/russross/blackfriday v2.0.0+incompatible
-	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
-)
+require github.com/gomarkdown/markdown v0.0.0-20200316172748-fd1f3374857d

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/russross/blackfriday v2.0.0+incompatible h1:cBXrhZNUf9C+La9/YpS+UHpUT8YD6Td9ZMSU9APFcsk=
-github.com/russross/blackfriday v2.0.0+incompatible/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
-github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
-github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/gomarkdown/markdown v0.0.0-20200316172748-fd1f3374857d h1:cFE/VFoUSjvIjrkI3YHGUYReJTIPN4fl2etwblBZfgg=
+github.com/gomarkdown/markdown v0.0.0-20200316172748-fd1f3374857d/go.mod h1:aii0r/K0ZnHv7G0KF7xy1v0A7s2Ljrb5byB7MO5p6TU=
+golang.org/dl v0.0.0-20190829154251-82a15e2f2ead/go.mod h1:IUMfjQLJQd4UTqG1Z90tenwKoCX93Gn3MAQJMOSBsDQ=

--- a/main.go
+++ b/main.go
@@ -30,7 +30,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/russross/blackfriday"
+	"github.com/gomarkdown/markdown"
+	"github.com/gomarkdown/markdown/parser"
 )
 
 var wd string
@@ -240,13 +241,14 @@ func load() ([]Article, []string, map[string]string) {
 
 	for i, a := range articles {
 		title, body := preProcess("articles/" + a.ID + ".md")
-		markdown := blackfriday.Run([]byte(body))
+		ext := parser.CommonExtensions | parser.AutoHeadingIDs
+		html := markdown.ToHTML([]byte(body), parser.NewWithExtensions(ext), nil)
 
 		t, err := time.Parse("2006-01-02", a.LastUpdated)
 		check(err)
 
 		a := Article{
-			Body:          template.HTML(markdown),
+			Body:          template.HTML(html),
 			Canonical:     a.Canonical,
 			Description:   a.Description,
 			ID:            a.ID,


### PR DESCRIPTION
I want to provide auto-heading links.

I was using an old version of blackfriday.
Its documentation is confusing due to its v1 to v2 migration.

gomarkdown is now the top result on Google for Go Markdown parsing.
It took less than 5 minutes to read and implement.

https://github.com/gomarkdown/markdown