### PR TITLE
theme: add robots.txt

### DIFF
--- a/theme/public/robots.txt
+++ b/theme/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
This functionally the same as having no robots.txt file.
But, it removes the top "resource not found" item in Netlify Analytics.

https://docs.netlify.com/monitor-sites/analytics/