### PR TITLE
articles/thin-api-clients: add

### DIFF
--- a/articles/thin-api-clients.md
+++ b/articles/thin-api-clients.md
@@ -1,0 +1,62 @@
+# Thin API Clients
+
+I've sometimes seen open source libraries
+used as a special-purpose API client for a SaaS service
+when a "thin" client written by the application developers
+would be a better choice.
+
+Here's an example of a "thin" API client:
+
+```embed
+code/slack_webhook.rb all
+```
+
+This triggers a
+[Slack incoming webhook](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks)
+from Ruby.
+
+I would rather write and maintain this code,
+which uses a generic [HTTP](https://github.com/httprb/http) dependency,
+than depend on a third-party library or package,
+such as a specific Slack client gem.
+
+Third-party packages have costs.
+They need to be managed by a package manager.
+They may need to be upgraded in the future
+to patch security issues
+or to resolve competing requirements in the dependency graph.
+They can become unmaintained.
+They are an additional interface for the team to learn.
+
+In the Ruby example, I used a third-party HTTP package
+because I like its interface better than the Ruby standard library's interface.
+A "thinner" client would use only the language's standard library.
+Here's a Go version of the same program:
+
+```embed
+code/slackwebhook.go all
+```
+
+If all I'm dealing with is a `POST` request,
+JSON body, and some lightweight authentication such as a header token,
+I would choose the thin client approach.
+
+If there are some lightweight idempotency key and retry logic,
+I may still choose to write a thin client.
+
+I would use a third-party package if the authentication mechanism
+is more complex or we need to use a large surface area of the API
+(many endpoints that may be stitched together).
+
+A middle ground is choosing the lightest weight option amongst
+multiple open source packages. For example, when I've written a feature to
+add a new credit card to a React Native app, I've used the
+[stripe-client](https://www.npmjs.com/package/stripe-client) Node package
+instead of alternatives that pull in iOS and Android dependencies.
+When all we need to do is get a token from Stripe's API,
+then send the token to our backend for processing,
+the heavier weight option is not worth the costs.
+
+```embed
+code/stripe-card-token.ts all
+```

--- a/articles/thin-api-clients.md
+++ b/articles/thin-api-clients.md
@@ -1,9 +1,9 @@
 # Thin API Clients
 
 I've sometimes seen open source libraries
-used as a special-purpose API client for a SaaS service
-when a "thin" client written by the application developers
-would be a better choice.
+used as an API client for a SaaS service
+when a better choice would be
+a "thin" client written by the application developers.
 
 Here's an example of a "thin" API client:
 
@@ -15,47 +15,44 @@ This triggers a
 [Slack incoming webhook](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks)
 from Ruby.
 
-I would rather write and maintain this code,
-which uses a generic [HTTP](https://github.com/httprb/http) dependency,
-than depend on a third-party library or package,
-such as a specific Slack client gem.
+I would rather write and maintain this code
+with a generic HTTP dependency
+than depend on a Slack-specific third-party library.
 
-Third-party packages have costs.
+Third-party libraries have costs.
 They need to be managed by a package manager.
-They may need to be upgraded in the future
-to patch security issues
-or to resolve competing requirements in the dependency graph.
+They may need to be upgraded to patch security issues
+or resolve competing requirements in the dependency graph.
 They can become unmaintained.
 They are an additional interface for the team to learn.
 
-In the Ruby example, I used a third-party HTTP package
-because I like its interface better than the Ruby standard library's interface.
-A "thinner" client would use only the language's standard library.
-Here's a Go version of the same program:
+In the Ruby example,
+I used a third-party [HTTP](https://github.com/httprb/http) library
+because I prefer its interface to the Ruby standard library's interface.
+A "thinner" client would use only the language's standard library,
+such as this Go version of the same program:
 
 ```embed
 code/slackwebhook.go all
 ```
 
-If all I'm dealing with is a `POST` request,
-JSON body, and some lightweight authentication such as a header token,
-I would choose the thin client approach.
+If my only needs are a `POST` request with JSON body,
+I would write a thin client.
+If there is some lightweight authentication with a header token,
+an idempotency key, or retry logic,
+I would still choose to write a thin client.
 
-If there are some lightweight idempotency key and retry logic,
-I may still choose to write a thin client.
+I would use a third-party library if the authentication mechanism
+is more complex or we need to use a large surface area of the API,
+stitching together many endpoints.
 
-I would use a third-party package if the authentication mechanism
-is more complex or we need to use a large surface area of the API
-(many endpoints that may be stitched together).
-
-A middle ground is choosing the lightest weight option amongst
-multiple open source packages. For example, when I've written a feature to
-add a new credit card to a React Native app, I've used the
+Another "thin" variation is
+to choose the lightest option of open source libraries.
+For example, to add a new credit card to a React Native app, I've used the
 [stripe-client](https://www.npmjs.com/package/stripe-client) Node package
-instead of alternatives that pull in iOS and Android dependencies.
-When all we need to do is get a token from Stripe's API,
-then send the token to our backend for processing,
-the heavier weight option is not worth the costs.
+instead of alternatives that have iOS and Android dependencies.
+In this case, we only need to get a token from Stripe's API
+and send the token to our backend for processing.
 
 ```embed
 code/stripe-card-token.ts all

--- a/code/slack_webhook.rb
+++ b/code/slack_webhook.rb
@@ -1,0 +1,12 @@
+# begindoc: all
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "http"
+end
+
+HTTP.post(ENV["SLACK_WEBHOOK"], json: {
+  text: "Hello, world!"
+})
+# enddoc: all

--- a/code/slackwebhook.go
+++ b/code/slackwebhook.go
@@ -1,0 +1,40 @@
+// begindoc: all
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	url := os.Getenv("SLACK_WEBHOOK")
+	if url == "" {
+		log.Fatalln("no webhook provided")
+	}
+
+	reqBody, err := json.Marshal(map[string]string{
+		"text": "Hello, world!",
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	resp, err := http.Post(url, "application/json", bytes.NewBuffer(reqBody))
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	fmt.Println(string(respBody))
+}
+
+// enddoc: all

--- a/code/stripe-card-token.ts
+++ b/code/stripe-card-token.ts
@@ -1,0 +1,31 @@
+// begindoc: all
+// https://dashboard.stripe.com/account/apikeys
+// It is fine to publish the Stripe Publishable key,
+// as it has no dangerous permissions.
+const PUBLISHABLE_API_KEY = "pk_test_1234567890abcdef";
+
+const client = require("stripe-client")(PUBLISHABLE_API_KEY);
+
+interface StripeCard {
+  address_zip: string;
+  cvc?: string; // usually required
+  exp_month: string; // two-digit number
+  exp_year: string; // two- or four-digit number
+  number: string;
+}
+
+const createCardToken = async (card: StripeCard): Promise<string | null> => {
+  // https://stripe.com/docs/api/tokens/create_card
+  const response = await client.createToken({ card });
+
+  if (response && response.id) {
+    return response.id;
+  } else {
+    return null;
+  }
+};
+
+export const stripe = {
+  createCardToken,
+};
+// enddoc: all

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "When to access a third-party API with an open source library vs. writing a custom, thin client",
+    "description": "When to access a third-party API with an open source library, when to write a custom, thin client",
     "id": "thin-api-clients",
     "last_updated": "2020-04-07",
     "tags": ["APIs"]

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   {
     "description": "When to access a third-party API with an open source library, when to write a custom, thin client",
     "id": "thin-api-clients",
-    "last_updated": "2020-04-07",
+    "last_updated": "2020-04-08",
     "tags": ["APIs"]
   },
   {

--- a/config.json
+++ b/config.json
@@ -1,5 +1,11 @@
 [
   {
+    "description": "When to access a third-party API with an open source library vs. writing a custom, thin client",
+    "id": "thin-api-clients",
+    "last_updated": "2020-04-07",
+    "tags": ["APIs"]
+  },
+  {
     "description": "Command-line script that accepts a GitHub username and generates a circular favicon and Apple Touch icon",
     "id": "favicon-apple-touch-icon-github-avatar",
     "last_updated": "2020-04-03",


### PR DESCRIPTION
Provide Ruby, Go, and TypeScript examples.