### PR TITLE
main.go: redirect /archive/* links to /

### DIFF
--- a/main.go
+++ b/main.go
@@ -257,7 +257,7 @@ func build() map[string]string {
 	cmd.Run()
 
 	// redirects
-	redirects := ""
+	redirects := "/archive/* /\n"
 	for k, v := range redirectMap {
 		redirects = redirects + k + " " + v + "\n"
 	}


### PR DESCRIPTION
After feed.json, the other 404s are all /archive requests.
Probably bots, but make it easier to read the analytics.