### PR TITLE
articles: rewrite Cache API Requests in current style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public/*
 !theme/public
+.env

--- a/code/cache-api-requests/main.rb
+++ b/code/cache-api-requests/main.rb
@@ -1,0 +1,67 @@
+# begindoc: all
+require "bundler/inline"
+require "digest"
+require "json"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "dotenv"
+  gem "http"
+  gem "pg"
+end
+
+Dotenv.load
+DB = PG.connect("postgres://postgres:postgres@localhost:5432/venues")
+
+class Foursquare
+  def self.explore(query, near:)
+    http = HTTP::Client.new
+    req = http.build_request(
+      :get,
+      "https://api.foursquare.com/v2/venues/explore",
+      params: {
+        client_id: ENV["FSQ_ID"],
+        client_secret: ENV["FSQ_SECRET"],
+        v: "20180323",
+        query: query,
+        near: near
+      }
+    )
+    hashed_uri = Digest::MD5.hexdigest(req.uri)
+
+    # lookup cache
+    result = DB.exec_params(<<~SQL, [hashed_uri])
+      SELECT resp_body
+      FROM cache_foursquare
+      WHERE hashed_uri = $1
+      AND fetched_at > now() - interval '24 hours';
+    SQL
+
+    if result.num_tuples == 1
+      # return cache if fresh in database
+      return [200, result[0]["resp_body"]]
+    end
+
+    # GET req.uri
+    resp = http.perform(req, HTTP::Options.new({}))
+
+    if resp.code != 200
+      # return error
+      return [resp.code, JSON.parse(resp.body)]
+    end
+
+    # add to cache, or update stale cache
+    DB.exec_params(<<~SQL, [hashed_uri, resp.body])
+      INSERT INTO cache_foursquare (fetched_at, hashed_uri, resp_body)
+      VALUES (now(), $1, $2)
+      ON CONFLICT (hashed_uri) DO UPDATE
+      SET fetched_at = EXCLUDED.fetched_at, resp_body = EXCLUDED.resp_body;
+    SQL
+
+    # return fresh data
+    [200, JSON.parse(resp.body)]
+  end
+end
+
+Foursquare.explore("tacos", near: "San Francisco, CA")
+# enddoc: all

--- a/code/cache-api-requests/schema.sql
+++ b/code/cache-api-requests/schema.sql
@@ -1,0 +1,13 @@
+-- begindoc: all
+-- createdb venues
+-- psql -d venues -f schema.sql
+
+CREATE TABLE cache_foursquare (
+  hashed_uri text NOT NULL,
+  resp_body jsonb NOT NULL,
+  fetched_at timestamp NOT NULL,
+  UNIQUE (hashed_uri)
+);
+
+CREATE INDEX hashed_uri_idx ON cache_foursquare (hashed_uri);
+-- enddoc: all

--- a/config.json
+++ b/config.json
@@ -1,5 +1,12 @@
 [
   {
+    "description": "Caching HTTP GET requests can improve performance and help avoid hitting rate limits",
+    "id": "cache-api-requests",
+    "last_updated": "2020-07-22",
+    "published": "2013-11-29",
+    "tags": ["APIs", "Backend"]
+  },
+  {
     "description": "When my production app processes change state on Heroku, I want to be notified in Slack",
     "id": "heroku-slack-aws-lambda",
     "last_updated": "2020-06-16",
@@ -238,13 +245,6 @@
     "published": "2013-12-02",
     "redirects": ["/polymorphic-activity-feed-with-rails"],
     "tags": ["Backend", "Frontend"]
-  },
-  {
-    "description": "Caching HTTP GET requests can improve performance and help avoid hitting rate limits",
-    "id": "cache-api-requests",
-    "last_updated": "2013-11-29",
-    "published": "2013-11-29",
-    "tags": ["APIs", "Backend"]
   },
   {
     "canonical": "https://thoughtbot.com/blog/faster-grepping-in-vim",


### PR DESCRIPTION
I've been writing most programs lately with fewer dependencies,
no ORMs, only a Postgres driver in the language used by the project.
This older article was starting to feel out of date.
Update it with the style I'd use to re-write the same program today.