### PR TITLE
all: extract dev.to articles

### DIFF
--- a/articles/format-sql-in-vim.md
+++ b/articles/format-sql-in-vim.md
@@ -1,0 +1,38 @@
+# Format SQL in Vim
+
+When I save a `.sql` file in Vim,
+it auto-formats it with `pgformatter`
+using the flags from my `ftplugin/sql.vim`.
+
+Install and configure
+[ALE](https://github.com/dense-analysis/ale) in `~/.vimrc`:
+
+```vim
+call plug#begin('~/.vim/plugged')
+  Plug 'dense-analysis/ale' " :help ale
+call plug#end()
+```
+
+In `~/.vim/ftplugin/sql.vim`:
+
+```vim
+" Auto-fix
+let b:ale_fixers = ['pgformatter']
+let g:ale_fix_on_save = 1
+let b:ale_sql_pgformatter_options = '--function-case 1 --keyword-case 2 --spaces 2 --no-extra-line'
+```
+
+In my [laptop.sh](https://github.com/croaky/laptop),
+I have a variant of the following that is idempotent;
+it will install or update [Homebrew](https://brew.sh/)
+and [pgFormatter](https://github.com/darold/pgFormatter):
+
+```bash
+# pgformatter
+brew install pgformatter
+
+# Vim plugins
+curl -fLo "$HOME/.vim/autoload/plug.vim" --create-dirs \
+  https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+vim -u "$HOME/.vimrc" +PlugUpdate +PlugClean! +qa
+```

--- a/articles/postgres-set-variable.md
+++ b/articles/postgres-set-variable.md
@@ -1,0 +1,48 @@
+# Postgres \set variable
+
+Within `psql`,
+you can `\set` variables and reference them with `:'var-name'`.
+For example:
+
+```sql
+\set query '%SaaS%'
+
+SELECT
+  'https://example.com/companies/' || companies.id AS url,
+  companies.name
+FROM
+  companies
+  JOIN notes ON notes.company_id = companies.id
+WHERE
+  companies.name ILIKE :'query'
+  OR companies.description ILIKE :'query'
+  OR notes.comments ILIKE :'query'
+GROUP BY
+  url,
+  companies.name
+ORDER BY
+  companies.name ASC;
+```
+
+When I run `<Leader>v` from a `.sql` file in Vim,
+I get a prompt to bind my variables.
+
+The configuration for this is in `~/.vim/ftplugin/sql.vim`:
+
+```vim
+" Prepare SQL command with var(s)
+nmap <buffer> <Leader>v :!clear && psql -d $(cat .db) -f % -v<SPACE>
+```
+
+I also have a `.db` file that contains only the local database name:
+
+```
+example_development
+```
+
+When I press enter,
+the variables are bound,
+the file's contents are run against my Postgres database through `psql`,
+and the output is printed to my screen.
+
+See `man psql` for more detail on the `-d`, `-f`, and `-v` flags.

--- a/articles/run-sql-from-vim.md
+++ b/articles/run-sql-from-vim.md
@@ -1,0 +1,20 @@
+# Run SQL from Vim
+
+When I run `<Leader>r` from a `.sql` file in Vim,
+the file's contents are run against my Postgres database through `psql`
+and the output is printed to my screen.
+
+The configuration for this is in `~/.vim/ftplugin/sql.vim`:
+
+```vim
+" Run current file
+nmap <buffer> <Leader>r :!clear && psql -d $(cat .db) -f %<CR>
+```
+
+I also have a `.db` file that contains only the local database name:
+
+```
+example_development
+```
+
+See `man psql` for more detail on the `-d` and `-f` flags.

--- a/config.json
+++ b/config.json
@@ -1,5 +1,26 @@
 [
   {
+    "description": "In psql, \\set variables and reference them with :'var-name'.",
+    "id": "postgres-set-variable",
+    "last_updated": "2020-12-05",
+    "published": "2020-12-05",
+    "tags": []
+  },
+  {
+    "description": "Run SQL against configured Postgres database from Vim.",
+    "id": "run-sql-from-vim",
+    "last_updated": "2020-09-21",
+    "published": "2020-09-21",
+    "tags": ["Data", "Workflow"]
+  },
+  {
+    "description": "Format SQL on save in Vim.",
+    "id": "format-sql-in-vim",
+    "last_updated": "2020-08-03",
+    "published": "2020-08-03",
+    "tags": ["Data", "Workflow"]
+  },
+  {
     "description": "Caching HTTP GET requests can improve performance and help avoid hitting rate limits",
     "id": "cache-api-requests",
     "last_updated": "2020-07-22",


### PR DESCRIPTION
This summer,
I wrote two quick tips on dev.to
about using Postgres from Vim:

https://dev.to/croaky/format-sql-on-save-run-sql-with-leader-r-296d
https://dev.to/croaky/postgres-set-variable-21ld

I would like to move them to my canonical blog.

Re-reading them, I realized they should be split into three articles.

Backdate as appropriate.