### PR TITLE
theme: fix low-hanging Lighthouse audit items

### DIFF
--- a/theme/article.html
+++ b/theme/article.html
@@ -213,7 +213,7 @@
   <div class="container">
     <nav>
       <a class="logo" href="/">
-        <img alt="GitHub avatar" src="logo.png" />
+        <img alt="GitHub avatar" src="logo.png" width="64px" height="64px" />
       </a>
     </nav>
 

--- a/theme/index.html
+++ b/theme/index.html
@@ -147,12 +147,14 @@
 <body>
   <div class="container">
     <nav>
-      <a class="logo" href="/"><img alt="GitHub avatar" src="logo.png" /></a>
+      <a class="logo" href="/">
+        <img alt="GitHub avatar" src="logo.png" width="64px" height="64px" />
+      </a>
     </nav>
 
     <ul class="social">
       <li>
-        <a href="https://github.com/croaky" target="_blank">
+        <a href="https://github.com/croaky" target="_blank" rel="noopener">
           <svg
             aria-label="GitHub"
             height="24"
@@ -168,7 +170,7 @@
         </a>
       </li>
       <li>
-        <a href="https://twitter.com/croaky" target="_blank">
+        <a href="https://twitter.com/croaky" target="_blank" rel="noopener">
           <svg
             aria-label="Twitter"
             height="24"

--- a/theme/public/_headers
+++ b/theme/public/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'none'; script-src 'sha256-mo0tZkJTtXeFomBaOzCfsvJ+qi0DKiC5K/fqC6R4rr4=' 'sha256-ff7fh+zjR1kC1fmsEa0x+XIDt5vPtbuaFuP0i+Ky+0s='; style-src 'unsafe-inline'; font-src 'self'; img-src 'self' data:; frame-ancestors 'none';
+  Content-Security-Policy: default-src 'none'; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; img-src 'self' data:; script-src 'sha256-mo0tZkJTtXeFomBaOzCfsvJ+qi0DKiC5K/fqC6R4rr4=' 'sha256-ff7fh+zjR1kC1fmsEa0x+XIDt5vPtbuaFuP0i+Ky+0s='; style-src 'unsafe-inline';
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block


### PR DESCRIPTION
Add `width` and `height` attributes to logo `img` tag.
https://web.dev/optimize-cls/#images-without-dimensions

Add `rel="noopener"` attribute for external anchors.
https://web.dev/external-anchors-use-rel-noopener/

Add `connect-src: 'self';` to CSP rules so Lighthouse can get robots.txt
https://github.com/nhoizey/nicolas-hoizey.com/commit/6b10c62bb897c8bd7ac425c823a9adfbe9766c32