### PR TITLE
all: remove JSON feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,6 @@ The `last_updated` date can be in the future.
 A [GitHub Action is scheduled daily](https://dancroak.com/schedule-netlify-builds-with-github-actions)
 to auto-publish to Netlify.
 
-The `published` date is used for the [JSON feed](https://jsonfeed.org/).
-
 The `redirects` are converted into a
 [Netlify _redirects file](https://docs.netlify.com/routing/redirects/).
 

--- a/config.json
+++ b/config.json
@@ -3,91 +3,78 @@
     "description": "Read and write to a Heroku Postgres database as primary and read from a follower in targeted call sites",
     "id": "heroku-postgres-read-replica-with-rails",
     "last_updated": "2021-02-26",
-    "published": "2021-02-26",
     "tags": ["Backend", "Data"]
   },
   {
     "description": "Use concat_ws() instead of concat() to avoid ugly output",
     "id": "postgres-concat-ws-function",
     "last_updated": "2020-12-05",
-    "published": "2020-12-05",
     "tags": ["Data"]
   },
   {
     "description": "In psql, set variables and reference them",
     "id": "postgres-set-variable",
     "last_updated": "2020-10-10",
-    "published": "2020-10-10",
     "tags": ["Data"]
   },
   {
     "description": "Run SQL against a Postgres database from Vim",
     "id": "run-sql-from-vim",
     "last_updated": "2020-09-21",
-    "published": "2020-09-21",
     "tags": ["Data", "Workflow"]
   },
   {
     "description": "Format SQL on save in Vim",
     "id": "format-sql-in-vim",
     "last_updated": "2020-08-03",
-    "published": "2020-08-03",
     "tags": ["Data", "Workflow"]
   },
   {
     "description": "Caching HTTP GET requests can improve performance and help avoid hitting rate limits",
     "id": "cache-api-requests",
     "last_updated": "2020-07-22",
-    "published": "2013-11-29",
     "tags": ["APIs", "Backend"]
   },
   {
     "description": "When my production app processes change state on Heroku, I want to be notified in Slack",
     "id": "heroku-slack-aws-lambda",
     "last_updated": "2020-06-16",
-    "published": "2020-06-16",
     "tags": ["APIs", "Backend", "Workflow"]
   },
   {
     "description": "A secure runtime for JavaScript and TypeScript",
     "id": "deno",
     "last_updated": "2020-05-26",
-    "published": "2020-05-26",
     "tags": ["APIs", "Backend"]
   },
   {
     "description": "When to access an API with a specialized library and when to write a custom thin client",
     "id": "thin-api-clients",
     "last_updated": "2020-04-08",
-    "published": "2020-04-08",
     "tags": ["APIs"]
   },
   {
     "description": "Command-line script that accepts a GitHub username and generates a circular favicon and Apple Touch icon",
     "id": "favicon-apple-touch-icon-github-avatar",
     "last_updated": "2020-04-03",
-    "published": "2020-04-03",
     "tags": ["Frontend"]
   },
   {
     "description": "Make ~/.ssh/authorized_keys look nicer",
     "id": "ssh-ed25519",
     "last_updated": "2020-04-01",
-    "published": "2020-04-01",
     "tags": ["Workflow"]
   },
   {
     "description": "Daily deploys with Netlify build hooks, GitHub Actions' scheduled workflows, and GitHub encrypted secrets",
     "id": "schedule-netlify-builds-with-github-actions",
     "last_updated": "2020-03-28",
-    "published": "2020-03-28",
     "tags": ["Workflow"]
   },
   {
     "description": "End-to-end with a kanban board, GitHub code review, continuous integration, and continuous delivery",
     "id": "pull-requests-and-kanban",
     "last_updated": "2020-03-26",
-    "published": "2020-03-26",
     "redirects": ["/feature-branch-code-reviews"],
     "tags": ["Workflow"]
   },
@@ -95,7 +82,6 @@
     "description": "Keep it synced with the upstream repository",
     "id": "update-a-github-fork",
     "last_updated": "2020-03-26",
-    "published": "2020-03-26",
     "redirects": ["/keep-a-github-fork-updated"],
     "tags": ["Workflow"]
   },
@@ -103,7 +89,6 @@
     "description": "Block ads, trackers, and malicious websites with /etc/hosts",
     "id": "block-etc-hosts",
     "last_updated": "2020-02-08",
-    "published": "2020-02-08",
     "redirects": ["/ad-block-at-etc-hosts", "/block-ads-etc-hosts"],
     "tags": ["Workflow"]
   },
@@ -111,7 +96,6 @@
     "description": "Avoid mistakes when editing prose in Markdown files and Git commit messages",
     "id": "spell-check-in-vim",
     "last_updated": "2018-11-12",
-    "published": "2018-11-12",
     "redirects": [
       "/avoid-team-wide-spelling-mistakes-with-vim",
       "/project-specific-spell-checking-vim",
@@ -123,7 +107,6 @@
     "description": "My laptop repo sets up a macOS machine as a software development environment",
     "id": "laptop-sh",
     "last_updated": "2018-11-12",
-    "published": "2018-11-12",
     "redirects": ["/laptop-setup-script"],
     "tags": ["Workflow"]
   },
@@ -131,7 +114,6 @@
     "description": "Clone a monorepo, change into the project directory, and run one command to start contributing",
     "id": "setup-sh",
     "last_updated": "2018-11-12",
-    "published": "2018-11-12",
     "redirects": ["/bin-setup"],
     "tags": ["Patterns", "Workflow"]
   },
@@ -139,21 +121,18 @@
     "description": "How we organized our code into a monorepo at our startup and how it evolved over time",
     "id": "monorepo",
     "last_updated": "2018-11-01",
-    "published": "2018-11-01",
     "tags": ["Patterns", "Workflow"]
   },
   {
     "description": "Define Unix processes in a manifest named Procfile and use tools to manage those processes",
     "id": "process-model",
     "last_updated": "2018-10-16",
-    "published": "2018-10-16",
     "tags": ["APIs", "Backend"]
   },
   {
     "description": "Dirs and files matching the patterns defined in this file are ignored for git commits, ag searches, and fzf searches",
     "id": "gitignore",
     "last_updated": "2018-06-21",
-    "published": "2018-06-21",
     "redirects": ["/global-gitignore"],
     "tags": ["Workflow"]
   },
@@ -161,35 +140,30 @@
     "description": "Deliver email from a Ruby on Rails app using Amazon's Simple Email Service (SES) hosted on EC2",
     "id": "email-amazon-ses-rails-ec2",
     "last_updated": "2018-05-09",
-    "published": "2018-05-09",
     "tags": ["Backend"]
   },
   {
     "description": "Set up and configure ASDF as a version manager for multiple programming languages",
     "id": "asdf-version-manager",
     "last_updated": "2018-05-07",
-    "published": "2018-05-07",
     "tags": ["Workflow"]
   },
   {
     "description": "A formatting style for prose that breaks lines at the end of a sentence or clause",
     "id": "semantic-linefeeds",
     "last_updated": "2018-05-03",
-    "published": "2018-05-03",
     "tags": ["Workflow"]
   },
   {
     "description": "Rather than pointing DNS directly to an origin server, point it to a CDN that pulls content from the origin",
     "id": "dns-cdn-origin",
     "last_updated": "2018-03-11",
-    "published": "2018-03-11",
     "tags": ["APIs", "Frontend"]
   },
   {
     "description": "A macOS setup and Vim configuration for React Native with Expo and Prettier",
     "id": "start-a-react-native-project",
     "last_updated": "2017-06-24",
-    "published": "2017-06-24",
     "redirects": [
       "/laptop-setup-and-vim-configuration-for-react-native",
       "/setup-react-native-laptop-vim"
@@ -201,7 +175,6 @@
     "description": "Align GitHub-Flavored Markdown tables in Vim in a few quick keystrokes",
     "id": "align-markdown-tables-in-vim",
     "last_updated": "2016-06-15",
-    "published": "2016-06-15",
     "redirects": [
       "/align-markdown-tables-vim",
       "/align-markdown-tables-with-vim"
@@ -213,7 +186,6 @@
     "description": "Steps to resolve the 'Compiled slug size: 300.1M is too large (max is 300M)' error",
     "id": "reduce-heroku-slug-size",
     "last_updated": "2016-06-13",
-    "published": "2016-06-13",
     "redirects": ["/reduce-a-large-heroku-compiled-slug-size"],
     "tags": ["Backend"]
   },
@@ -222,7 +194,6 @@
     "description": "How to build a retention curve chart in Google Sheets from a Mixpanel tabular cohort report",
     "id": "retention-curves-mixpanel-google-sheets",
     "last_updated": "2015-07-01",
-    "published": "2015-07-01",
     "redirects": ["/create-a-retention-curve-with-mixpanel-and-google-sheets"],
     "tags": ["Growth", "Workflow"]
   },
@@ -231,7 +202,6 @@
     "description": "Speed up Postgres full-text searches with a tsvector column as cache and trigger to keep the cache updated",
     "id": "postgres-full-text-search-tsvectors-triggers",
     "last_updated": "2015-06-25",
-    "published": "2015-06-25",
     "redirects": [
       "/optimize-postgres-full-text-search-with-tsvector-columns-and-triggers"
     ],
@@ -241,7 +211,6 @@
     "description": "Heroku routing errors don't reach error-tracking code in app processes, have to track with a logging service",
     "id": "log-alert-heroku-routing-errors",
     "last_updated": "2015-04-21",
-    "published": "2015-04-21",
     "redirects": [
       "/post/send-your-apps-heroku-routing-errors-to-slack-with-papertrail-alerts/",
       "/heroku-routing-errors-slack-papertrail"
@@ -252,7 +221,6 @@
     "description": "Tradeoffs for unit tests that use mocks, stubs, or spies",
     "id": "test-mock-vs-stub-vs-spy",
     "last_updated": "2015-03-19",
-    "published": "2015-03-19",
     "redirects": ["/test-spies-vs-mocks"],
     "tags": ["Patterns"]
   },
@@ -261,7 +229,6 @@
     "description": "How many people get authentic value from our product?",
     "id": "north-star-metric",
     "last_updated": "2014-12-25",
-    "published": "2014-12-25",
     "tags": ["Growth"]
   },
   {
@@ -269,7 +236,6 @@
     "description": "The general programming technique of polymorphism can be applied to Rails partials",
     "id": "polymorphic-activity-feed-rails",
     "last_updated": "2013-12-02",
-    "published": "2013-12-02",
     "redirects": ["/polymorphic-activity-feed-with-rails"],
     "tags": ["Backend", "Frontend"]
   },
@@ -278,7 +244,6 @@
     "description": "Search a project for files, text, or word under cursor",
     "id": "search-projects-in-vim",
     "last_updated": "2013-11-27",
-    "published": "2013-11-27",
     "redirects": [
       "/fast-search-vim",
       "/fast-search-with-vim",
@@ -290,7 +255,6 @@
     "description": "Runs focused tests from Vim with a keystroke",
     "id": "run-tests-vim",
     "last_updated": "2013-08-05",
-    "published": "2013-08-05",
     "redirects": ["/run-specs-with-vim"],
     "tags": ["Workflow"]
   },
@@ -299,7 +263,6 @@
     "description": "Use Postgres' CONCURRENTLY option for CREATE INDEX to avoid locking writes to a table",
     "id": "create-postgres-indexes-concurrently",
     "last_updated": "2013-07-30",
-    "published": "2013-07-30",
     "tags": ["Backend", "Data"]
   },
   {
@@ -307,7 +270,6 @@
     "description": "Wrap text to set textwidth with visual select and gq",
     "id": "wrap-text-in-vim",
     "last_updated": "2013-04-07",
-    "published": "2013-04-07",
     "redirects": [
       "/wrap-existing-text-at-80-characters-with-vim",
       "/wrap-text-80-characters-vim"
@@ -319,7 +281,6 @@
     "description": "Sort lines alphabetically with visual select and :sort",
     "id": "sort-lines-in-vim",
     "last_updated": "2013-02-01",
-    "published": "2013-02-01",
     "redirects": [
       "/sort-lines-alphabetically-vim",
       "/sort-lines-alphabetically-with-vim"
@@ -331,7 +292,6 @@
     "description": "Configure an email whitelist for a staging Rails to avoid accidentally delivering content outside the team",
     "id": "intercept-email-from-staging",
     "last_updated": "2013-01-18",
-    "published": "2013-01-18",
     "tags": ["Backend"]
   },
   {
@@ -339,14 +299,12 @@
     "description": "A pattern for unit tests (but not integration tests)",
     "id": "four-phase-test",
     "last_updated": "2012-09-28",
-    "published": "2012-09-28",
     "tags": ["Patterns"]
   },
   {
     "description": "Extend an object's responsibilities without subclassing",
     "id": "decorators-ruby",
     "last_updated": "2011-12-26",
-    "published": "2011-12-26",
     "redirects": ["/implement-decorators-with-ruby"],
     "tags": ["Patterns"]
   },
@@ -355,7 +313,6 @@
     "description": "Back up and restore a production database backup into staging or local environment",
     "id": "back-up-restore-heroku-postgres-databases",
     "last_updated": "2011-08-18",
-    "published": "2011-08-18",
     "redirects": ["/back-up-and-restore-heroku-postgres-databases"],
     "tags": ["Backend", "Data", "Workflow"]
   },
@@ -364,7 +321,6 @@
     "description": "Ruby's pessimistic operator with Semantic Versioning can help stabilize dependencies",
     "id": "pessimistic-operator-ruby",
     "last_updated": "2010-12-29",
-    "published": "2010-12-29",
     "redirects": ["/rubys-pessimistic-operator"],
     "tags": ["Backend", "Patterns"]
   },
@@ -372,7 +328,6 @@
     "description": "How to implement a common interface for configuring a third-party library in Ruby",
     "id": "config-block-ruby",
     "last_updated": "2010-01-20",
-    "published": "2010-01-20",
     "redirects": [
       "/configuration-block-pattern-with-ruby",
       "/configuration-block-ruby"
@@ -383,7 +338,6 @@
     "description": "Associations through a User model enforce authorization concerns without additional code",
     "id": "authorization-rails-associations",
     "last_updated": "2009-08-12",
-    "published": "2009-08-12",
     "redirects": ["/authorization-with-rails-associations"],
     "tags": ["Backend"]
   },
@@ -392,7 +346,6 @@
     "description": "An anti-pattern that hides cause and effect because part of it is done outside the test method",
     "id": "mystery-guests-in-tests",
     "last_updated": "2009-07-28",
-    "published": "2009-07-28",
     "redirects": ["/mystery-guest"],
     "tags": ["Patterns"]
   }

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,4 @@ module github.com/croaky/blog
 
 go 1.14
 
-require (
-	github.com/gomarkdown/markdown v0.0.0-20200316172748-fd1f3374857d
-	github.com/kr/jsonfeed v0.1.0
-	github.com/kr/pretty v0.2.0 // indirect
-)
+require github.com/gomarkdown/markdown v0.0.0-20200316172748-fd1f3374857d

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,3 @@
 github.com/gomarkdown/markdown v0.0.0-20200316172748-fd1f3374857d h1:cFE/VFoUSjvIjrkI3YHGUYReJTIPN4fl2etwblBZfgg=
 github.com/gomarkdown/markdown v0.0.0-20200316172748-fd1f3374857d/go.mod h1:aii0r/K0ZnHv7G0KF7xy1v0A7s2Ljrb5byB7MO5p6TU=
-github.com/kr/jsonfeed v0.1.0 h1:ATRwJDTIiDSQz/hHL/JNV8enpYRAw1YzIgMx4P8gq1A=
-github.com/kr/jsonfeed v0.1.0/go.mod h1:5KY9wFVvmD69yWQZr2YcNMRjKL7K1TSidlyIvFAkZcc=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
-github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
-github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 golang.org/dl v0.0.0-20190829154251-82a15e2f2ead/go.mod h1:IUMfjQLJQd4UTqG1Z90tenwKoCX93Gn3MAQJMOSBsDQ=

--- a/theme/article.html
+++ b/theme/article.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{.Article.Title}}</title>
   <meta name="author" content="Dan Croak">
-  <link rel="alternate" href="feed.json" type="application/json" />
   {{- if .Article.Canonical }}
   <link rel="canonical" href="{{.Article.Canonical}}">
   {{- end }}

--- a/theme/index.html
+++ b/theme/index.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Short articles about software" />
-  <link rel="alternate" href="feed.json" type="application/json" />
   <link rel="apple-touch-icon" href="apple-touch-icon.png">
   <title>Dan Croak</title>
   <style>


### PR DESCRIPTION
I'm removing the JSON feed because:

* I don't use a feed reader.
  So, it's difficult to test whether anything is funky with it.
* The code is simpler.
* I treat the site more like a wiki than a blog.
  Maybe the project name should change?

I don't know if people are using the feed but
if anyone wants to follow along,
I've started a [newsletter](https://dancroak.substack.com/)
and added a button linking to it in the footer.