### PR TITLE
theme/article: remove newsletter CTA in footer

### DIFF
--- a/articles/mystery-guests-in-tests.md
+++ b/articles/mystery-guests-in-tests.md
@@ -1,4 +1,4 @@
-# Mystery Guests in Tests
+# Mystery Guest
 
 > You're having trouble understanding the behavior a test is verifying.
 

--- a/config.json
+++ b/config.json
@@ -275,7 +275,7 @@
   },
   {
     "canonical": "https://thoughtbot.com/blog/four-phase-test",
-    "description": "A pattern for unit tests (but not integration tests)",
+    "description": "A pattern for Ruby unit tests (but not integration tests)",
     "id": "four-phase-test",
     "last_updated": "2012-09-28",
     "tags": ["Ruby"]
@@ -289,14 +289,14 @@
   },
   {
     "canonical": "https://thoughtbot.com/blog/rubys-pessimistic-operator",
-    "description": "Ruby's pessimistic operator with Semantic Versioning can help stabilize dependencies",
+    "description": "Stabilize Ruby dependencies with the pessimistic operator and Semantic Versioning",
     "id": "pessimistic-operator-ruby",
     "last_updated": "2010-12-29",
     "redirects": ["/rubys-pessimistic-operator"],
     "tags": ["Ruby"]
   },
   {
-    "description": "Configure a third-party library in Ruby",
+    "description": "Configure a Ruby library",
     "id": "config-block-ruby",
     "last_updated": "2010-01-20",
     "redirects": [
@@ -307,7 +307,7 @@
   },
   {
     "canonical": "https://thoughtbot.com/blog/mystery-guest",
-    "description": "An anti-pattern that hides cause and effect because part of it is done outside the test method",
+    "description": "An anti-pattern in Ruby tests that hides cause and effect",
     "id": "mystery-guests-in-tests",
     "last_updated": "2009-07-28",
     "redirects": ["/mystery-guest"],

--- a/theme/article.html
+++ b/theme/article.html
@@ -166,20 +166,6 @@
     th {
       text-align: left;
     }
-    .newsletter {
-      font-size: 20px;
-      margin-top: 2rem;
-    }
-    .newsletter a {
-      background-color: var(--purple);
-      color: var(--white);
-      max-width: 25rem;
-      padding: 1rem;
-      width: 100%;
-    }
-    .newsletter a:hover {
-      color: var(--white);
-    }
     @media (max-width: 1000px) {
       .container {
         margin: 2rem;
@@ -209,13 +195,6 @@
       p {
         margin: 1rem 0;
       }
-      .newsletter {
-        font-size: 16px;
-        width: 180px;
-      }
-      .newsletter a {
-        padding: 0.75rem;
-      }
     }
   </style>
 </head>
@@ -241,12 +220,6 @@
 
     <footer>
       <a href="/">&larr; All articles</a>
-
-      <div class="newsletter">
-        <a href="https://dancroak.substack.com/subscribe">
-          Get email updates
-        </a>
-      </div>
     </footer>
   </div>
 


### PR DESCRIPTION
Keep the page cleaner, only one CTA in footer: back to index.