### PR TITLE
articles/ssh-ed25519: update flag

### DIFF
--- a/articles/ssh-ed25519.md
+++ b/articles/ssh-ed25519.md
@@ -46,5 +46,13 @@ Host github.com
 Add the private key to the SSH agent on macOS:
 
 ```
-ssh-add -K ~/.ssh/id_ed25519
+ssh-add --apple-use-keychain ~/.ssh/id_ed25519
 ```
+
+Copy the public key to macOS clipboard:
+
+```
+cat ~/.ssh/id_ed25519.pub | pbcopy
+```
+
+[Upload the public key to GitHub](https://github.com/settings/keys).

--- a/config.json
+++ b/config.json
@@ -84,7 +84,7 @@
   {
     "description": "Make ~/.ssh/authorized_keys look nicer",
     "id": "ssh-ed25519",
-    "last_updated": "2020-04-01",
+    "last_updated": "2022-01-24",
     "tags": ["Infra"]
   },
   {


### PR DESCRIPTION
`ssh-add -K` has been replaced by `ssh-add --apple-use-keychain`.

Include copy-paste into GitHub to finish off process.