### PR TITLE
articles/run-sql-in-vim: use :redraw! instead of clear

### DIFF
--- a/articles/run-sql-in-vim.md
+++ b/articles/run-sql-in-vim.md
@@ -8,7 +8,7 @@ The configuration for this is in `~/.vim/ftplugin/sql.vim`:
 
 ```vim
 " Run current file
-nmap <buffer> <Leader>r :!clear && psql -d $(cat .db) -f %<CR>
+nmap <buffer> <Leader>r :redraw!<CR>:!psql -d $(cat .db) -f %<CR>
 ```
 
 I also have a `.db` file that contains only the local database name:


### PR DESCRIPTION
Previously, I would see output containing the sequence `^[[H^[[2J`,
an ANSI escape code for clearing the screen. In many terminals:

- `^[[H` moves the cursor to the home position (i.e., the top-left of
  the screen).
- `^[[2J` clears the screen from the cursor to the end of the screen.

When I ran the `clear` command, it sends these escape sequences to the
terminal to clear the screen. However, when I run the command from
within Vim using `:!`, Vim captures and displays the output of the
command, including the escape sequences, which don't get interpreted but
rather get shown as is.

To avoid seeing the escape sequences, replace the `clear` command with
another approach. One way to achieve this without the escape sequences
being printed is by using Vim's built-in command to clear the screen:
`:redraw!`.

```vim
nmap <buffer> <Leader>r :redraw!<CR>:!psql -d $(cat .db) -f %<CR>
```

With this, `:redraw!` will clear Vim's command-line screen. After that,
the SQL command will run, giving me a clean output.
